### PR TITLE
Update README.md with working build instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ Features:
 ### usage:
 
  ```
- $ git clone git@github.com:maydavid/rtl-dab.git
+ $ git clone https://github.com/maydavid/rtl-dab.git
  $ cd rtl-dab
  $ cmake .
- $ src/rtl_dab <frequency in Hz>
+ $ make
+ $ ./src/rtl_dab <frequency in Hz>
  ```
  


### PR DESCRIPTION
This also removes certificate warning recieved due to original github URI.